### PR TITLE
:sparkles: add parsing of query array values

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,6 +1,6 @@
 'use strict';
 /* jshint latedef: nofunc */
-/* NOTE: this is because fo the recursive nature of the functions here
+/* NOTE: this is because of the recursive nature of the functions here
     we must be able to call parseObject from inside parseValue,
     if the value is an object
 */

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,11 +1,57 @@
 'use strict';
+/* jshint latedef: nofunc */
+/* NOTE: this is because fo the recursive nature of the functions here
+    we must be able to call parseObject from inside parseValue,
+    if the value is an object
+*/
 
 /**
- * Attempts to recursively convert object properties to dates.
+ * Convert string to boolean.
+ * @param  {String}  string  - String to convert
+ * @return {?}  Returns the results of the conversion.
+*/
+function parseBoolFromString(string) {
+  if (string === 'true') {
+    return true;
+  }
+  else if (string === 'false') {
+    return false;
+  }
+  else {
+    return string;
+  }
+}
+
+/**
+ * Recursively test values for conversion.
+ * @param  {?}  value  - String to convert
+ * @return {?}  Returns the results of the conversion.
+*/
+function parseValue(value) {
+  if (typeof value === 'string') {
+    return parseBoolFromString(value);
+  }
+  else if (value.constructor === Object) {
+    return parseObject(value);
+  }
+  else if (Array.isArray(value)) {
+    var array = [];
+    value.forEach(function(item, itemKey) {
+      array[itemKey] = parseValue(item);
+    });
+    return array;
+  }
+  else {
+    return value;
+  }
+}
+
+/**
+ * Recursively convert object strings to boolean.
  * @param  {Object}  obj  - Object to iterate over
  * @return {Object}  Returns new object (shallow copy).
 */
-function parse(obj) {
+function parseObject(obj) {
   var result = {},
       key,
       value;
@@ -13,34 +59,11 @@ function parse(obj) {
   for (key in obj) {
     if (obj.hasOwnProperty(key)) {
       value = obj[key];
-
-      if (typeof value === 'string') {
-        if (value === 'true') {
-          result[key] = true;
-        }
-        else if (value === 'false') {
-          result[key] = false;
-        }
-        else {
-          result[key] = value;
-        }
-      }
-      else if (value.constructor === Object) {
-        result[key] = parse(value);
-      }
-      else if (Array.isArray(value)) {
-        value.forEach(function(item, itemKey) {
-          value[itemKey] = parse(item);
-        });
-        result[key] = value;
-      }
-      else {
-        result[key] = value;
-      }
+      result[key] = parseValue(value);
     }
   }
 
   return result;
 }
 
-module.exports = parse;
+module.exports = parseObject;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -28,6 +28,12 @@ function parse(obj) {
       else if (value.constructor === Object) {
         result[key] = parse(value);
       }
+      else if (Array.isArray(value)) {
+        value.forEach(function(item, itemKey) {
+          value[itemKey] = parse(item);
+        });
+        result[key] = value;
+      }
       else {
         result[key] = value;
       }

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -89,6 +89,28 @@ exports.parser = {
     );
 
     test.done();
+  },
+
+  array: function(test) {
+    test.deepEqual(
+      parser({
+        array: [
+          { a: 'true' },
+          { b: 'false' },
+          { c: 'test' },
+        ],
+      }),
+      {
+        array: [
+          { a: true },
+          { b: false },
+          { c: 'test' },
+        ],
+      },
+      'Recursively parses array.'
+    );
+
+    test.done();
   }
 
 };


### PR DESCRIPTION
If you have query with the following structure: 
```
{
  stuff: [
    { thing: 'false' },
  ],
}
```
The current checks would not convert the value of `thing` to the booleon  false. 

This pull requests adds the ability to iterate over an Array and call parse on it's contents. 

I haven't looked at the tests for this project, but this is working for me locally. Will hopefully have time to update the test tomorrow.